### PR TITLE
Corrected object processing during piece generation

### DIFF
--- a/src/FractureRig.py
+++ b/src/FractureRig.py
@@ -55,10 +55,10 @@ def modifyGeo(nodes, geometryNodes, nodePieces, numPieces, root):
 
         tempName = geometryNodes[objectToProcess].parent().name()
 
-        if(refGeo.parent().node("UNPACK")  == None):
-            unpack = refGeo.parent().createNode("unpack", "UNPACK")
-        elif (refGeo.parent().node("UNPACK")  != None):
-            unpack = refGeo.parent().node("UNPACK")
+        if(refGeo.parent().node("UNPACK" + str(objectToProcess))  == None):
+            unpack = refGeo.parent().createNode("unpack", "UNPACK" + str(objectToProcess))
+        elif (refGeo.parent().node("UNPACK" + str(objectToProcess))  != None):
+            unpack = refGeo.parent().node("UNPACK" + str(objectToProcess))
         else:
             print "ERROR 0: Cannot generate unpack node!"
 
@@ -99,6 +99,8 @@ def modifyGeo(nodes, geometryNodes, nodePieces, numPieces, root):
             #creation frame and the next frame.
             #################################
             xform.setFirstInput(delete)
+            xform.setDisplayFlag(True)
+            xform.setRenderFlag(True)
             xform.parm('movecentroid').pressButton()
 
             creationFrame = nodes[objectToProcess].parm('createframe').eval()
@@ -125,9 +127,9 @@ def modifyGeo(nodes, geometryNodes, nodePieces, numPieces, root):
             #################################
             #Delete original file node
             #################################
-            if(str(hou.node(root.path() + "/" + tempName + "_PIECE" + str(index) + "/file1")) != "None"):
-                hou.node(root.path() + "/" + tempName + "_PIECE" + str(index) + "/file1").destroy()
-            hou.node(root.path() + "/" + tempName + "_PIECE" + str(index)).layoutChildren()
+            if(xform.parent().node('file1') != None):
+                xform.parent().node("file1").destroy()
+            xform.parent().layoutChildren()
 
 def processMesh(nodes, nodePieces, numPieces):
     PARMS   =   ["tx", "ty", "tz", "rx", "ry", "rz", "px", "py", "pz"]


### PR DESCRIPTION
1. Tool now correctly generates unpack nodes for ALL selected RBD Packed Objects.
2. Explicitly setting display/render flags for generated pieces.
3. Indexing was wrong for node removal, so did a much better method of removing the leftover 'file1' node from the pieces.
4. In turn, the modified indexing method was applied to laying out the generated nodes.
