### PR TITLE
[tools_updater_fix] Fixed the repository URL to use HTTPS

### DIFF
--- a/toolbar/game_development_toolset.shelf
+++ b/toolbar/game_development_toolset.shelf
@@ -37,7 +37,7 @@ from PySide2.QtGui import *
 from PySide2.QtWidgets import *
 import hou
 
-REPO_URL = 'http://api.github.com/repos/sideeffects/GameDevelopmentToolset'
+REPO_URL = 'https://api.github.com/repos/sideeffects/GameDevelopmentToolset'
 BRANCHES = ["Stable", "Development"]
 
 SETTINGS_FILE = os.path.join(os.getenv("HOUDINI_USER_PREF_DIR"), "gamedevtoolset.json")


### PR DESCRIPTION
Even thought the HTTP version used in a browser is redirected to the HTTPS version
the updater script returns a timeout error.

I have tested this with Houdini Apprentice 16.5.323