### PR TITLE
fga export: fixed slowness and added interruptableOperation wrapper

### DIFF
--- a/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/DialogScript
+++ b/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/DialogScript
@@ -19,7 +19,7 @@
         label   "Render"
         type    button
         default { "0" }
-        parmtag { "script_callback" "hou.pwd().hdaModule().renderFGA()" }
+        parmtag { "script_callback" "hou.pwd().hdaModule().renderFile()" }
         parmtag { "script_callback_language" "python" }
     }
     parm {

--- a/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
+++ b/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
@@ -1,5 +1,6 @@
 import io
 import struct
+import ctypes
 
 def renderFile():
     node = hou.pwd()
@@ -83,21 +84,30 @@ def renderFGB():
     out_stream = io.open(fgaFile,'wb')
     out_stream.write(header)
 
-    with hou.InterruptableOperation("Saving FGA", long_operation_name="Saving vector field",
+    format = struct.Struct('3f')
+    bufferLength=10000
+    buffer = bytearray(format.size * bufferLength)
+    with hou.InterruptableOperation("Saving FGB 2", long_operation_name="Saving vector field",
                                     open_interrupt_dialog=True) as operation:
         try:
             total_to_write = resolution[0] * resolution[1] * resolution[2]
             total_written = 0
+            total_in_buffer = 0
             for y in range(resolution[1]):
                 for z in range(resolution[2]):
                     for x in range(resolution[0]):
-                        value = struct.pack('3f', vel_x.voxel((x, y, z)), vel_z.voxel((x, y, z)), vel_y.voxel((x, y, z)))
-                        out_stream.write(value)
+                        format.pack_into(buffer,total_in_buffer * format.size, vel_x.voxel((x, y, z)), vel_z.voxel((x, y, z)), vel_y.voxel((x, y, z)))
                         total_written += 1
-                        if total_written % 1000 == 0:
+                        total_in_buffer += 1
+                        if total_in_buffer == bufferLength:
+                            out_stream.write(buffer)
+                            total_in_buffer = 0
                             percent = float(total_written) / float(total_to_write)
                             operation.updateProgress(percent)
 
+            if total_in_buffer > 0:
+                chunk = buffer[0:total_in_buffer+1]
+                out_stream.write(chunk)
         except hou.OperationInterrupted:
             print "User cancelled vector file save"
         except:

--- a/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
+++ b/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
@@ -17,18 +17,33 @@ def renderFGA():
     fgaText += "%f,%f,%f,\n" % (minvec[0], minvec[2], minvec[1])
     fgaText += "%f,%f,%f,\n" % (maxvec[0], maxvec[2], maxvec[1])
 
-    voxelValues = ""
-    for y in range(resolution[1]):
-        for z in range(resolution[2]):
-            for x in range(resolution[0]):
-                #print "%d,%d,%d" % (x,y,z)
-                voxelValues += "%f,%f,%f,\n" % (velx.voxel((x,y,z)), velz.voxel((x,y,z)), vely.voxel((x,y,z)))
-                #print "(%f,%f,%f)" % (x,y,z)
-            
-    fgaText += voxelValues
-
-    #print fgaText
-
     file = open(fgaFile, "w")
-    file.write(fgaText)
+    with hou.InterruptableOperation("Saving FGA", long_operation_name ="Saving vector field", open_interrupt_dialog = True) as operation:
+        try:
+            file.write(fgaText)
+
+            outlist = []
+            written_this_block = 0
+            total_to_write=resolution[0]*resolution[1]*resolution[2]
+            total_written=0
+            for y in range(resolution[1]):
+                for z in range(resolution[2]):
+                    for x in range(resolution[0]):
+                        outlist.append("%f,%f,%f,\n" % (velx.voxel((x,y,z)), velz.voxel((x,y,z)), vely.voxel((x,y,z))))
+                        written_this_block += 1
+                        total_written += 1
+                        if written_this_block > 1000000:
+                            file.write("".join(outlist))
+                            outlist = []
+                            written_this_block = 0
+                            percent = float(total_written) / float(total_to_write)
+                            operation.updateProgress(percent)
+
+            if written_this_block > 0:
+                file.write("".join(outlist))
+        except hou.OperationInterrupted:
+            print "User cancelled vector file save"
+        except:
+            print "exception thrown while saving vector file"
+
     file.close()

--- a/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
+++ b/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
@@ -107,7 +107,7 @@ def renderFGB():
                             operation.updateProgress(percent)
 
             if total_in_buffer > 0:
-                chunk = buffer[0:total_in_buffer+1]
+                chunk = buffer[0:((total_in_buffer+1)* format.size)]
                 out_stream.write(chunk)
         except hou.OperationInterrupted:
             print "User cancelled vector file save"

--- a/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
+++ b/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
@@ -103,6 +103,7 @@ def renderFGB():
                             out_stream.write(buffer)
                             total_in_buffer = 0
                             percent = float(total_written) / float(total_to_write)
+                            print("percent complete = " + str(int(percent*100)))
                             operation.updateProgress(percent)
 
             if total_in_buffer > 0:

--- a/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
+++ b/otls/rop_vector_field.hda/gamedev_8_8Sop_1rop__vector__field/PythonModule
@@ -1,3 +1,15 @@
+import io
+import struct
+
+def renderFile():
+    node = hou.pwd()
+    file_name = node.parm("outputFile").eval()
+    if file_name.endswith("fga"):
+        renderFGA()
+    else:
+        renderFGB()
+
+
 def renderFGA():
     node = hou.pwd()
     OUT = hou.node("%s/OUT" % node.path())
@@ -45,5 +57,50 @@ def renderFGA():
             print "User cancelled vector file save"
         except:
             print "exception thrown while saving vector file"
+        finally:
+            file.close()
 
-    file.close()
+
+def renderFGB():
+    node = hou.pwd()
+    OUT = hou.node("%s/OUT" % node.path())
+    geo = OUT.geometry()
+    fgaFile = node.parm("outputFile").eval()
+
+    vel_x = geo.prims()[0]
+    vel_y = geo.prims()[1]
+    vel_z = geo.prims()[2]
+
+    resolution = vel_x.resolution()
+    bounds = vel_x.boundingBox()
+    min_vec = bounds.minvec() * 100
+    max_vec = bounds.maxvec() * 100
+
+    header = struct.pack('3i6f', resolution[0], resolution[2], resolution[1],
+                         min_vec[0], min_vec[2], min_vec[1],
+                         max_vec[0], max_vec[2], max_vec[1])
+
+    out_stream = io.open(fgaFile,'wb')
+    out_stream.write(header)
+
+    with hou.InterruptableOperation("Saving FGA", long_operation_name="Saving vector field",
+                                    open_interrupt_dialog=True) as operation:
+        try:
+            total_to_write = resolution[0] * resolution[1] * resolution[2]
+            total_written = 0
+            for y in range(resolution[1]):
+                for z in range(resolution[2]):
+                    for x in range(resolution[0]):
+                        value = struct.pack('3f', vel_x.voxel((x, y, z)), vel_z.voxel((x, y, z)), vel_y.voxel((x, y, z)))
+                        out_stream.write(value)
+                        total_written += 1
+                        if total_written % 1000 == 0:
+                            percent = float(total_written) / float(total_to_write)
+                            operation.updateProgress(percent)
+
+        except hou.OperationInterrupted:
+            print "User cancelled vector file save"
+        except:
+            print "exception thrown while saving vector file"
+        finally:
+            out_stream.close()


### PR DESCRIPTION
the previous version did simple string concatenation which would slow down exponentially as the export size grew larger (and could possibly result in out-of-memory errors). The new version uses a fixed length string array as a buffer. Since export of large files can still take a long time the operation is now wrapped in an InterruptableOperation to allow the user to cancel and to give progress feedback.