### PR TITLE
Fix GoZ crash in Houdini 17

### DIFF
--- a/otls/sop_goz_io.hda/gamedev_8_8Sop_1sop__goz__export/GoZBrushToHoudini.py
+++ b/otls/sop_goz_io.hda/gamedev_8_8Sop_1sop__goz__export/GoZBrushToHoudini.py
@@ -47,7 +47,8 @@ def create_new_goz_instance():
             
         else:
             go_z_node = hou.node("/obj").createNode("geo", "GoZ_Mesh")
-            go_z_node.node("file1").destroy()    
+            if go_z_node.node("file1"):
+                go_z_node.node("file1").destroy()    
             go_z_node.moveToGoodPosition()
             goz_instance = go_z_node.createNode("sop_goz_import", "GoZ_Mesh")
 


### PR DESCRIPTION
Newly created geometry nodes don't contain a "file1" node in Houdini 17
therefore the `GoZBrushToHoudini.py` script raises an error when trying
to delete this node.