### PR TITLE
Handle opdef: in OSM import sop.

### DIFF
--- a/otls/sop_osm_import.hda/gamedev_8_8Sop_1sop__osm__import/Contents.dir/Contents.mime
+++ b/otls/sop_osm_import.hda/gamedev_8_8Sop_1sop__osm__import/Contents.dir/Contents.mime
@@ -114,6 +114,7 @@ version 0.8
 python	[ 0	locks=0 ]	(	"import re
 from math import sin, cos, sqrt, atan2, radians
 import xml.etree.cElementTree as ET
+import StringIO
 
 try:
     from PySide2.QtGui import QColor
@@ -424,8 +425,16 @@ class OSMParser(object):
 
         self.tags = list(set(tags))
 
+# Make a File Object
+def make_file_object(filename):
+    if filename.startswith(\"opdef:\") or filename.startswith(\"oplib:\"):
+        return StringIO.StringIO(hou.readFile(filename))
+    else:
+        return file(filename, \"r\")
+
 osm_file = hou.node(\"..\").parm(\"osm_file\").eval()
-parser = OSMParser(osm_file)
+osm_file_object = make_file_object(osm_file) 
+parser = OSMParser(osm_file_object)
 parser.parse()
 parser.build()
 "	)


### PR DESCRIPTION
Turn the input path (either filename or opdef: path) into a Python File Object so that `ET.iterparse` can handle either one.

Fixes #167.